### PR TITLE
Sound Effects

### DIFF
--- a/UnityProject/Assets/Runtime/GameClasses/commandpost/PhxCommandpost.cs
+++ b/UnityProject/Assets/Runtime/GameClasses/commandpost/PhxCommandpost.cs
@@ -80,7 +80,7 @@ public class PhxCommandpost : PhxInstance<PhxCommandpost.ClassProperties>, IPhxT
 
         AudioAmbient = gameObject.AddComponent<AudioSource>();
         AudioAmbient.spatialBlend = 1.0f;
-        AudioAmbient.clip = SoundLoader.LoadSound("com_blg_commandpost2");
+        AudioAmbient.clip = SoundLoader.Instance.LoadSound("com_blg_commandpost2");
         AudioAmbient.pitch = 1.0f;
         AudioAmbient.volume = 0.5f;
         AudioAmbient.rolloffMode = AudioRolloffMode.Linear;

--- a/UnityProject/Assets/Runtime/GameClasses/weapons/PhxGenericWeapon.cs
+++ b/UnityProject/Assets/Runtime/GameClasses/weapons/PhxGenericWeapon.cs
@@ -106,7 +106,7 @@ public class PhxGenericWeapon : PhxInstance<PhxGenericWeapon.ClassProperties>, I
     {   
         if (C.FireSound.Get() != null)
         {
-            AudioClip FireSound = SoundLoader.LoadSound(C.FireSound.Get());
+            AudioClip FireSound = SoundLoader.Instance.LoadSound(C.FireSound.Get());
 
             if (FireSound != null)
             {
@@ -250,7 +250,7 @@ public class PhxGenericWeapon : PhxInstance<PhxGenericWeapon.ClassProperties>, I
             {
                 // PitchSpread was previously used here to vary the sound pitch, that was a misunderstanding
                 // as PitchSpread is part of the weapon's aim spread, not sound
-                Audio.Play();
+                Audio.PlayOneShot(Audio.clip, 1.0f);
             }
 
             if (SalvoIndex < C.SalvoCount)

--- a/UnityProject/Assets/Runtime/PhxAnimationLoader.cs
+++ b/UnityProject/Assets/Runtime/PhxAnimationLoader.cs
@@ -63,7 +63,7 @@ public static class PhxAnimationLoader
 
         uint dummyroot = HashUtils.GetCRC("dummyroot");
 
-        uint[] boneCRCs = bank.GetBoneCRCs();
+        uint[] boneCRCs = bank.GetBoneCRCs(animNameCRC);
         List<CraBone> bones = new List<CraBone>();
         for (int i = 0; i < boneCRCs.Length; ++i)
         {

--- a/UnityProject/Assets/Runtime/PhxMatch.cs
+++ b/UnityProject/Assets/Runtime/PhxMatch.cs
@@ -217,7 +217,7 @@ public class PhxMatch
 
             if (UIBack == null)
             {
-                UIBack = SoundLoader.LoadSound("ui_menuBack");
+                UIBack = SoundLoader.Instance.LoadSound("ui_menuBack");
             }
             GAME.PlayUISound(UIBack, 1.2f);
         }

--- a/UnityProject/Assets/Runtime/PhxPropertyDB.cs
+++ b/UnityProject/Assets/Runtime/PhxPropertyDB.cs
@@ -89,7 +89,7 @@ public sealed class PhxPropertyDB
         }
         else if (destType == typeof(AudioClip))
         {
-            outVal = Convert.ChangeType(SoundLoader.LoadSound(value), destType, CultureInfo.InvariantCulture);
+            outVal = Convert.ChangeType(SoundLoader.Instance.LoadSound(value), destType, CultureInfo.InvariantCulture);
         }
         else if (destType == typeof(SWBFPath))
         {

--- a/UnityProject/Assets/Runtime/UI/Button/PhxButton.cs
+++ b/UnityProject/Assets/Runtime/UI/Button/PhxButton.cs
@@ -36,8 +36,8 @@ public class PhxButton : MonoBehaviour, IPointerClickHandler, IPointerEnterHandl
         Center.texture = TextureLoader.Instance.ImportUITexture("bf2_buttons_items_center");
         Right.texture  = TextureLoader.Instance.ImportUITexture("bf2_buttons_botright");
 
-        HoverSound = SoundLoader.LoadSound("ui_menumove");
-        ClickSound = SoundLoader.LoadSound("ui_planetzoom");
+        HoverSound = SoundLoader.Instance.LoadSound("ui_menumove");
+        ClickSound = SoundLoader.Instance.LoadSound("ui_planetzoom");
     }
 
     void Update()

--- a/UnityProject/Assets/Runtime/UI/CharacterSelect/PhxCharacterItem.cs
+++ b/UnityProject/Assets/Runtime/UI/CharacterSelect/PhxCharacterItem.cs
@@ -86,7 +86,7 @@ public class PhxCharacterItem : MonoBehaviour, IPointerClickHandler, IPointerEnt
         boxTexDst.SetPixels32(boxTexSrc.GetPixels32());
         boxTexDst.Apply();
 
-        Sound = SoundLoader.LoadSound("ui_menumove");
+        Sound = SoundLoader.Instance.LoadSound("ui_menumove");
     }
 
     void Update()

--- a/UnityProject/Assets/Runtime/UI/Map/PhxUIMap.cs
+++ b/UnityProject/Assets/Runtime/UI/Map/PhxUIMap.cs
@@ -80,7 +80,7 @@ public class PhxUIMap : MonoBehaviour
         MapMat = image.materialForRendering;
         Debug.Assert(MapMat != null);
 
-        CPSelectSound = SoundLoader.LoadSound("ui_menumove");
+        CPSelectSound = SoundLoader.Instance.LoadSound("ui_menumove");
 
         // TODO: Load texture from "MapTexture" property specified in PhxCommandpost class
         Texture2D cpTexture = TextureLoader.Instance.ImportUITexture("hud_flag_icon");

--- a/UnityProject/Assets/Runtime/UI/TextListBox/PhxListBoxItem.cs
+++ b/UnityProject/Assets/Runtime/UI/TextListBox/PhxListBoxItem.cs
@@ -129,7 +129,7 @@ public class PhxListBoxItem : MonoBehaviour, IPointerEnterHandler, IPointerExitH
         Debug.Assert(Icon2 != null);
         Debug.Assert(Txt != null);
 
-        HoverSound = SoundLoader.LoadSound("ui_menumove");
+        HoverSound = SoundLoader.Instance.LoadSound("ui_menumove");
     }
 
     void Update()


### PR DESCRIPTION
Minor changes to Phx and LVLImport needed to integrate progress in the libSWBF2 `sound_overhaul` PR
- `SoundLoader` uses `Instance` singleton like all the others
-  Very basic `Config` indirection via `SoundLoader:: InitializeSoundProperties(Level lvl)`.  This is called every time `PhxEnvironment` loads a level.  Resetting the SoundLoader DB does not clear the indirection mapping as the needed SoundProperties are fields of one big `Config` (which isn't referenced by name) and thus must be initialized all at once when a `Level` is loaded.  This is wasteful but once we get a proper sound wrapping system in place it'll be removed.  For now I just want sound effects to be regularly tested so we can catch any bugs in `SampleBank` reading.
- `SoundBank`/`bnk` code removed