### PR TITLE
Map anims

### DIFF
--- a/UnityProject/Assets/Runtime/GameClasses/building/PhxDestructableBuilding.cs
+++ b/UnityProject/Assets/Runtime/GameClasses/building/PhxDestructableBuilding.cs
@@ -9,7 +9,7 @@ using LibSWBF2.Wrappers;
 using System.Runtime.ExceptionServices;
 
 
-public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.ClassProperties>, IPhxTickable
+public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.ClassProperties>, IPhxTickable, IPhxDamageableInstance
 {
     protected static PhxScene SCENE => PhxGame.GetScene();
 
@@ -33,7 +33,11 @@ public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.Class
     public GameObject BuiltGeometry;
     public GameObject DestroyedGeometry;
 
+
+    public float Health;
+
     protected bool IsBuilt = true;
+
 
 
 
@@ -123,6 +127,8 @@ public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.Class
     {
         float HealthPercent = CurHealth.Get() / C.MaxHealth.Get();
 
+        Health = CurHealth.Get();
+
         if (HealthPercent > 0.0001f)
         {
             if (!IsBuilt)
@@ -131,6 +137,9 @@ public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.Class
                 DestroyedGeometry.SetActive(false);
                 
                 IsBuilt = true;
+
+                // Call respawn events
+                PhxLuaEvents.InvokeParameterized(PhxLuaEvents.Event.OnObjectRespawnName, gameObject.name.ToLower());
             }
 
             foreach (PhxDamageEffect DamageEffect in DamageEffects)
@@ -148,9 +157,26 @@ public class PhxDestructableBuilding : PhxInstance<PhxDestructableBuilding.Class
                 DestroyedGeometry.SetActive(true);
 
                 IsBuilt = false;
+
+                // Call death events
+                PhxLuaEvents.InvokeParameterized(PhxLuaEvents.Event.OnObjectKillName, gameObject.name.ToLower());
             }
         }
     }
 
     public override void Destroy(){}
+
+
+    public void AddDamage(float damage)
+    {
+        if (CurHealth.Get() > 0f)
+        {
+            CurHealth.Set(-1f);
+        }
+        else 
+        {
+            CurHealth.Set(1f);
+        }
+    }
+
 }

--- a/UnityProject/Assets/Runtime/GameClasses/ordnances/bolt/PhxBolt.cs
+++ b/UnityProject/Assets/Runtime/GameClasses/ordnances/bolt/PhxBolt.cs
@@ -95,6 +95,11 @@ public class PhxBolt : PhxOrdnance
 
     void OnCollisionEnter(Collision coll)
     {
+        if (coll.rigidbody != null)
+        {
+            ((IPhxDamageableInstance) coll.rigidbody.gameObject.GetComponent<PhxInstance>())?.AddDamage(100f);
+        }
+
         if (gameObject.activeSelf)
         {
             OnHit?.Invoke(this, coll);

--- a/UnityProject/Assets/Runtime/PhxInstance.cs
+++ b/UnityProject/Assets/Runtime/PhxInstance.cs
@@ -111,6 +111,17 @@ public interface IPhxControlableInstance
     IPhxWeapon GetPrimaryWeapon();
 }
 
+
+public interface IPhxDamageableInstance
+{
+    public void AddDamage(float Damage);
+}
+
+
+
+
+
+
 public abstract class PhxControlableInstance<T> : PhxInstance<T>, IPhxControlableInstance where T : PhxClass
 {
     protected PhxPawnController Controller;

--- a/UnityProject/Assets/Runtime/PhxLuaAPI.cs
+++ b/UnityProject/Assets/Runtime/PhxLuaAPI.cs
@@ -660,24 +660,29 @@ public static class PhxLuaAPI
 		
 	}
 
-	public static void PlayAnimation(string animName)
+	public static void EnableBarriers(string barrierName)
 	{
 		
 	}
 
+	public static void PlayAnimation(string animName)
+	{
+		RTS.Animator.PlayAnimation(animName.ToLower());
+	}
+
 	public static void PlayAnimationFromTo(string animName, float start, float end)
 	{
-
+		
 	}
 
 	public static void PauseAnimation(string animName)
     {
-
+		RTS.Animator.PauseAnimation(animName.ToLower());
     }
 
 	public static void RewindAnimation(string animName)
 	{
-
+		RTS.Animator.RewindAnimation(animName.ToLower());
 	}
 
 	public static void BlockPlanningGraphArcs(string planNodeName)
@@ -1170,7 +1175,7 @@ public static class PhxLuaAPI
 	}
 	public static void OnObjectKillName(PhxLuaRuntime.LFunction callback, string objName)
 	{
-		
+		PhxLuaEvents.Register(PhxLuaEvents.Event.OnObjectKillName, callback, objName.ToLower());
 	}
 	public static void OnObjectKillTeam(PhxLuaRuntime.LFunction callback, int teamIdx)
 	{
@@ -1182,7 +1187,7 @@ public static class PhxLuaAPI
 	}
 	public static void OnObjectRespawnName(PhxLuaRuntime.LFunction callback, string objName)
 	{
-		
+		PhxLuaEvents.Register(PhxLuaEvents.Event.OnObjectRespawnName, callback, objName.ToLower());		
 	}
 
 	public static void OnObjectRepairName(PhxLuaRuntime.LFunction callback, string objName)
@@ -1224,6 +1229,8 @@ public static class PhxLuaEvents
 		OnFinishCaptureName,
 		OnFinishCaptureTeam,
 		OnFinishNeutralize,
+		OnObjectKillName,
+		OnObjectRespawnName,
 	}
 
 	/// <summary>
@@ -1315,6 +1322,10 @@ public static class PhxLuaEvents
 				callbacks[i].Invoke(eventArgs);
 				Debug.Log($"Invoked Lua callback for '{ev}'");
 			}
+		}
+		else 
+		{
+			Debug.Log($"Failed to find callback for '{ev}'");
 		}
 	}
 

--- a/UnityProject/Assets/Runtime/PhxScene.cs
+++ b/UnityProject/Assets/Runtime/PhxScene.cs
@@ -53,6 +53,9 @@ public class PhxScene
     int InstanceCounter;
 
 
+    public PhxSceneAnimator Animator { get; private set; }
+
+
     public PhxScene(PhxEnvironment env, Container c)
     {
         ENV = env;
@@ -61,6 +64,8 @@ public class PhxScene
 
         ModelLoader.Instance.PhyMat = PhxGame.Instance.GroundPhyMat;
         ENV.OnPostLoad += CalcCPCamPositions;
+
+        Animator = new PhxSceneAnimator();
     }
 
     public void SetProperty(string instName, string propName, object propValue)
@@ -269,6 +274,9 @@ public class PhxScene
 
             WorldRoots.Add(worldRoot);
         }
+
+        Animator.InitializeAnimations(worldLayers);
+        Animator.InitializeAnimationGroups(worldLayers);        
     }
 
     public SWBFPath GetPath(string pathName)

--- a/UnityProject/Assets/Runtime/PhxScene.cs
+++ b/UnityProject/Assets/Runtime/PhxScene.cs
@@ -275,8 +275,7 @@ public class PhxScene
             WorldRoots.Add(worldRoot);
         }
 
-        Animator.InitializeAnimations(worldLayers);
-        Animator.InitializeAnimationGroups(worldLayers);        
+        Animator.InitializeWorldAnimations(worldLayers);        
     }
 
     public SWBFPath GetPath(string pathName)

--- a/UnityProject/Assets/Runtime/PhxSceneAnimator.cs
+++ b/UnityProject/Assets/Runtime/PhxSceneAnimator.cs
@@ -14,16 +14,19 @@ using System.Reflection;
 public class PhxAnimationGroup
 {
     List<Animation> Animators;
+    List<Vector3> StartPoints;
     List<string>    AnimationNames;
 
     public PhxAnimationGroup()
     {
         Animators = new List<Animation>();
         AnimationNames = new List<string>();
+        StartPoints = new List<Vector3>();
     }
 
     public bool AddInstanceAnimationPair(Animation anim, string AnimationName)
     {
+        StartPoints.Add(anim.gameObject.transform.position);
         Animators.Add(anim);
         AnimationNames.Add(AnimationName);
 
@@ -43,11 +46,13 @@ public class PhxAnimationGroup
     {
         for (int i = 0; i < Animators.Count; i++)
         {
+            Animators[i].gameObject.transform.parent.position = StartPoints[i];
+            Animators[i].gameObject.transform.localPosition = Vector3.zero;
+            
             Animators[i].enabled = true;
             Animators[i].Play(AnimationNames[i]);
 
             AnimationState aState = Animators[i][AnimationNames[i]];
-            aState.speed = 3f;
         }
     }
 
@@ -58,9 +63,16 @@ public class PhxAnimationGroup
             Animators[i].Rewind(AnimationNames[i]);
         }   
     }
+
+    public void SetStartPoint()
+    {
+        for (int i = 0; i < Animators.Count; i++)
+        {
+            Transform tx = Animators[i].gameObject.transform;
+            StartPoints[i] = tx.position;
+        }
+    }
 }
-
-
 
 
 
@@ -162,6 +174,8 @@ public class PhxSceneAnimator
                 }
             }
         }
+
+
     }
 
 

--- a/UnityProject/Assets/Runtime/PhxSceneAnimator.cs
+++ b/UnityProject/Assets/Runtime/PhxSceneAnimator.cs
@@ -1,0 +1,224 @@
+using System;
+using System.Collections.Generic;
+using UnityEngine;
+using LibSWBF2.Wrappers;
+using LibSWBF2.Enums;
+
+#if UNITY_EDITOR
+using UnityEditor;
+using System.Reflection;
+#endif
+
+
+
+public class PhxAnimationGroup
+{
+    List<Animation> Animators;
+    List<string>    AnimationNames;
+
+    public PhxAnimationGroup()
+    {
+        Animators = new List<Animation>();
+        AnimationNames = new List<string>();
+    }
+
+    public bool AddInstanceAnimationPair(Animation anim, string AnimationName)
+    {
+        Animators.Add(anim);
+        AnimationNames.Add(AnimationName);
+
+        return true;
+    }
+
+
+    public void Pause()
+    {
+        foreach (Animation anim in Animators)
+        {
+            anim.enabled = false;
+        }
+    }
+
+    public void Play()
+    {
+        for (int i = 0; i < Animators.Count; i++)
+        {
+            Animators[i].enabled = true;
+            Animators[i].Play(AnimationNames[i]);
+        }
+    }
+
+    public void Rewind()
+    {
+        for (int i = 0; i < Animators.Count; i++)
+        {
+            Animators[i].Rewind(AnimationNames[i]);
+        }   
+    }
+}
+
+
+
+
+
+
+
+
+
+public class PhxSceneAnimator
+{
+    Dictionary<string, AnimationClip> AnimDB;
+    Dictionary<string, PhxAnimationGroup> AnimGroupDB;
+   
+    public PhxSceneAnimator()
+    {
+        AnimDB = new Dictionary<string, AnimationClip>();
+        AnimGroupDB = new Dictionary<string, PhxAnimationGroup>();
+    }
+
+
+    public void InitializeAnimations(World[] worlds)
+    {
+        foreach (World wld in worlds)
+        {
+            InitializeAnimations(wld);
+        }
+    }
+
+    public void InitializeAnimations(World world)
+    {
+        WorldAnimation[] worldAnims = world.GetAnimations();
+
+        foreach (WorldAnimation anim in worldAnims)
+        {
+            if (AnimDB.ContainsKey(anim.Name))
+            {
+                continue;
+            }
+
+            AnimationCurve[] rKeys = AnimationLoader.Instance.GetWorldAnimationRotationCurves(anim);
+            AnimationCurve[] pKeys = AnimationLoader.Instance.GetWorldAnimationPositionCurves(anim);
+
+            AnimationClip clip = new AnimationClip();
+            clip.legacy = true;
+            clip.name = anim.Name;
+
+            if (rKeys != null)
+            {
+                clip.SetCurve("", typeof(Transform), "localEulerAngles.x", rKeys[0]);
+                clip.SetCurve("", typeof(Transform), "localEulerAngles.y", rKeys[1]);
+                clip.SetCurve("", typeof(Transform), "localEulerAngles.z", rKeys[2]);
+            }
+
+            if (pKeys != null)
+            {
+                clip.SetCurve("", typeof(Transform), "localPosition.x", pKeys[0]);
+                clip.SetCurve("", typeof(Transform), "localPosition.y", pKeys[1]);
+                clip.SetCurve("", typeof(Transform), "localPosition.z", pKeys[2]);  
+            } 
+
+            clip.wrapMode = anim.IsLooping ? WrapMode.Loop : WrapMode.ClampForever;
+
+            AnimDB[anim.Name] = clip;
+        }
+    }
+        
+
+
+    public void InitializeAnimationGroups(World[] wlds)
+    {
+        foreach (World wld in wlds)
+        {
+            InitializeAnimationGroups(wld);
+        }
+    }
+
+    public void InitializeAnimationGroups(World world)
+    {
+        foreach (WorldAnimationGroup animGroup in world.GetAnimationGroups())
+        {
+            if (AnimGroupDB.ContainsKey(animGroup.Name)) continue;
+
+            PhxAnimationGroup newAnimGroup = new PhxAnimationGroup();
+            AnimGroupDB[animGroup.Name.ToLower()] = newAnimGroup;
+
+            List<Tuple<string,string>> AnimInstPairs = animGroup.GetAnimationInstancePairs();
+            foreach (var pair in AnimInstPairs)
+            {
+                GameObject instance = GameObject.Find(pair.Item2);
+                AnimationClip clip = AnimDB.ContainsKey(pair.Item1) ? AnimDB[pair.Item1] : null;
+
+                if (instance == null || clip == null)
+                {
+                    continue;
+                }
+
+                instance.isStatic = false;
+
+
+                // string path = AnimationUtility.CalculateTransformPath(instance, WorldRoot.transform);
+                // Debug.LogFormat("  Instance: {0} will be animated by {1}", instanceObj.name, pair.Item1);
+
+                Animation anim = instance.GetComponent<Animation>();
+                if (anim == null)
+                {
+                    anim = instance.AddComponent<Animation>();
+                }
+
+                if (instance.transform.parent.gameObject.name != instance.name + "_animroot")
+                {
+                    GameObject dummmyPrnt = new GameObject(instance.name + "_animroot");
+                    dummmyPrnt.transform.position = instance.transform.position;
+                    dummmyPrnt.transform.rotation = instance.transform.rotation;
+                    dummmyPrnt.transform.SetParent(instance.transform.parent, true);
+
+                    instance.transform.SetParent(dummmyPrnt.transform, true);                         
+                }
+
+                anim.AddClip(clip, clip.name);
+
+                if (animGroup.PlaysAtStart)
+                {
+                    anim.clip = clip;
+                    anim.playAutomatically = true;
+                    anim.Play();
+                }
+
+                newAnimGroup.AddInstanceAnimationPair(anim, clip.name);
+            }
+        }
+    }
+
+
+    public bool PlayAnimation(string AnimationGroupName)
+    {
+        if (AnimGroupDB.TryGetValue(AnimationGroupName, out PhxAnimationGroup grp))
+        {
+            grp.Play();
+            return true;
+        }
+        return false;
+    }
+
+    public bool RewindAnimation(string AnimationGroupName)
+    {
+        if (AnimGroupDB.TryGetValue(AnimationGroupName, out PhxAnimationGroup grp))
+        {
+            grp.Play();
+            return true;
+        }
+
+        return false;
+    }
+
+    public bool PauseAnimation(string AnimationGroupName)
+    {
+        if (AnimGroupDB.TryGetValue(AnimationGroupName, out PhxAnimationGroup grp))
+        {
+            grp.Pause();
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/UnityProject/Assets/Runtime/PhxSceneAnimator.cs.meta
+++ b/UnityProject/Assets/Runtime/PhxSceneAnimator.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cd3332cce1dcb4589bd51517259d9aa8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Had this mostly done for a while now, decided to get local translation anims done this weekend.  Changes include:
- Anim API functions in `PhxLuaAPI`
- Map animation playback and registration handled in `PhxSceneAnimator` (w/legacy anims ofc)
- Since most map anims are related to destruction events, a dummy interface for adding damage (`IPhxDamageableInstance`) was added and is used by `PhxDestructableBuilding` to test Lua events that tie anims to object death.  This will be overhauled whenever we decide on the proper approach to damage.
- New map anim commits added to `LVLImport` and updated in submodule index
- Some rarer API calls might not be handled by `PhxSceneAnimator` so I'll add them as they're encountered by testing